### PR TITLE
fix: selfRevokeSigner update issue

### DIFF
--- a/contracts/paymasters/PermissionlessPaymaster.sol
+++ b/contracts/paymasters/PermissionlessPaymaster.sol
@@ -374,9 +374,9 @@ contract PermissionlessPaymaster is IPaymaster, EIP712 {
      * @dev To reduce impact of griefing attacks where a malicious manager frontruns and adds unrelated signer
      */
     function selfRevokeSigner() public {
-        previousManager = managers[msg.sender];
+        address _oldManager = managers[msg.sender];
         managers[msg.sender] = address(0);
-        emit SignerRevoked(previousManager, msg.sender);
+        emit SignerRevoked(_oldManager, msg.sender);
     }
     /**
      * @notice Allow manager to add multiple signers

--- a/test/PermissionlessPaymaster/unit.test.ts
+++ b/test/PermissionlessPaymaster/unit.test.ts
@@ -794,4 +794,25 @@ describe("PermissionlessPaymaster", () => {
             expect(await erc20.balanceOf(await paymaster.ZYFI_TREASURY())).to.be.equal(5);
         });
     });
+
+    //// -----------------------------------------------
+    //// Post audit -  fix test
+    //// -----------------------------------------------
+    
+    describe("Post audit fix test", async () => {
+        it("self revoke should not update previousManager", async () => {
+            // Setup
+            await paymaster.connect(Manager2).depositAndAddSigner(signer2.address,{
+                value: ethers.utils.parseEther("0.1")
+            });
+            await executeERC20Transaction(erc20, paymaster, user1, signer2);
+            expect(await paymaster.previousManager()).to.be.eq(Manager2.address);
+            // Self revoke signer call
+            await paymaster.connect(signer2).selfRevokeSigner();
+            // Checks
+            await expect(executeERC20Transaction(erc20, paymaster, user1, signer2)).to.be.rejectedWith("0x81c0c5d4");
+            expect(await paymaster.previousManager()).to.be.eq(Manager2.address);
+            expect(await paymaster.managers(signer2.address)).to.be.eq(ZERO_ADDRESS);
+        });
+    });
 });


### PR DESCRIPTION
Description: Fix to ensure `selfRevokeSigner()` do not update previousManager and event is emitted correctly.